### PR TITLE
Add sass bulma and style resources support

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1,0 +1,9 @@
+@charset "utf-8";
+// Define variables here
+$danger: #232323;
+$primary: red;
+
+// Bulma is imported and variables defined above would be used instead of default
+// You can make the styles even more optimized by explicitly importing only the components
+// you need, instead of importing the whole Bulma framework
+@import '~bulma/bulma';

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -26,8 +26,7 @@ export default {
   /*
   ** Global CSS
   */
-  css: [
-  ],
+  css: ['~/assets/scss/main.scss'],
 
   /*
   ** Plugins to load before mounting the App
@@ -41,8 +40,8 @@ export default {
   modules: [
     // Doc: https://axios.nuxtjs.org/usage
     '@nuxtjs/axios',
-    // Doc:https://github.com/nuxt-community/modules/tree/master/packages/bulma
-    '@nuxtjs/bulma',
+    // Doc: https://github.com/nuxt-community/style-resources-module
+    '@nuxtjs/style-resources',
     '@nuxtjs/dotenv'
   ],
   /*
@@ -50,6 +49,16 @@ export default {
   */
   axios: {
     // See https://github.com/nuxt-community/axios-module#options
+  },
+
+
+  /*
+  ** Style-resources configuration
+  */
+  styleResources: {
+    scss: [
+      '~/assets/scss/main.scss',
+    ]
   },
 
   /*

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   },
   "devDependencies": {
     "@nuxtjs/dotenv": "^1.3.0",
-    "nodemon": "^1.18.9"
+    "@nuxtjs/style-resources": "^0.1.2",
+    "node-sass": "^4.11.0",
+    "nodemon": "^1.18.9",
+    "sass-loader": "^7.1.0"
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -42,3 +42,9 @@
         },
     };
 </script>
+<style lang="scss" scoped>
+.section {
+    // Style resources allow to use variables and functions in vue files
+    background: $danger;
+}
+</style>


### PR DESCRIPTION
This PR allows bulma to be customised from a central ```assets/scss/main.scss``` file. Just redefine the variables provided by bulma and you're good to go.
Also I've added an extra feature ```style-resources``` which allow to use variables globally in ```.vue``` files

So here's how to enable bulma customization through scss for future reference:
1) ```npm install --save-dev node-sass sass-loader``` Enables sass support for the project
2) Create a sass file where you would import bulma, see the ```assets/scss/main.scss``` file for reference
3) Remove ```@nuxtjs/bulma``` module from ```nuxt.config```
4) Add your sass file to the css array in ```nuxt.config```
Now you're good to go with customizing bulma through a central file

For the variables to be available globally in ```.vue``` files follow this [tutorial](https://hackernoon.com/how-i-use-scss-variables-mixins-functions-globally-in-nuxt-js-projects-while-compiling-css-utilit-58bb6ff30438) the first part only

Please run ```npm-install``` once you merge the changes 🚀 

Any feedback is appreciated, thank you